### PR TITLE
missing var puts 'game' and 'map' in hero's global scope

### DIFF
--- a/crucible.js
+++ b/crucible.js
@@ -171,12 +171,12 @@ Crucible.prototype.getRandomMap = function() {
 //Creates a board from the map in the given file path
 Crucible.prototype.createGameFromMap = function(mapFilePath){
   var buffer = fs.readFileSync(mapFilePath);
-  map = buffer.toString('utf8');
+  var map = buffer.toString('utf8');
   map = map.split('\n');
   for (var i = 0; i < map.length; i++){
     map[i] = map[i].split('|');
   }
-  game = new Game(map.length);
+  var game = new Game(map.length);
   for (var j = 0; j < map.length; j++){
     for (var k = 0; k < map.length; k++){
       if (map[j][k] === 'DM'){


### PR DESCRIPTION
createGameFromMap omits "var" when it creates the game, so it gets created globally instead of locally, visible to heroes.

I accidentally accessed the global "game" in my bot, and it existed globally in the crucible so I didn't notice my mistake in testing, but it caused exceptions in the website battles.